### PR TITLE
Fix incorrect className generation from file path in `getCompiledClassName` method

### DIFF
--- a/codegen/src/main/java/io/automatiko/engine/codegen/process/ProcessExecutableModelGenerator.java
+++ b/codegen/src/main/java/io/automatiko/engine/codegen/process/ProcessExecutableModelGenerator.java
@@ -53,7 +53,7 @@ public class ProcessExecutableModelGenerator {
     }
 
     private String getCompiledClassName(Path fileNameRelative) {
-        return fileNameRelative.toString().replace("/", ".").replace(".java", "");
+        return fileNameRelative.toString().replace(".java", "").replace("/", ".");
     }
 
     public String extractedProcessId() {


### PR DESCRIPTION
Summary: The original implementation of this method led to incorrect class name generation when the file path contained the substring /java. 

Issue: Previously, a file path like "com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java" would incorrectly generate the class name "com.amazon.sqsmessaging.AmazonSQSExtendedClient". This was due to the premature removal of the /java segment.

Testing: `getCompiledClassName` is a private method not invoked by any other method. Creating a unit test is not feasible.