### PR TITLE
Reduce the footprint published to Maven Central

### DIFF
--- a/archetypes/automatiko-archetype/pom.xml
+++ b/archetypes/automatiko-archetype/pom.xml
@@ -16,6 +16,13 @@
   <name>Automatiko Engine :: Maven Archetypes :: Service</name>
   <description>Automatiko Service Archetype</description>
 
+  <properties>
+    <!-- An archetype jar already is the sources: the -sources.jar produced here is a
+      byte-for-byte duplicate of the archetype artifact, so publishing it only burns
+      Maven Central file-count quota. -->
+    <maven.source.skip>true</maven.source.skip>
+  </properties>
+
   <build>
     <!-- default directory (test-classes) confuses @QuarkusTest -->
     <!-- see https://github.com/quarkusio/quarkus/issues/9162   -->

--- a/archetypes/automatiko-batch-archetype/pom.xml
+++ b/archetypes/automatiko-batch-archetype/pom.xml
@@ -16,6 +16,13 @@
   <name>Automatiko Engine :: Maven Archetypes :: Batch</name>
   <description>Automatiko Service for batch processing Archetype</description>
 
+  <properties>
+    <!-- An archetype jar already is the sources: the -sources.jar produced here is a
+      byte-for-byte duplicate of the archetype artifact, so publishing it only burns
+      Maven Central file-count quota. -->
+    <maven.source.skip>true</maven.source.skip>
+  </properties>
+
   <build>
     <!-- default directory (test-classes) confuses @QuarkusTest -->
     <!-- see https://github.com/quarkusio/quarkus/issues/9162   -->

--- a/archetypes/automatiko-db-archetype/pom.xml
+++ b/archetypes/automatiko-db-archetype/pom.xml
@@ -16,6 +16,13 @@
   <name>Automatiko Engine :: Maven Archetypes :: Database</name>
   <description>Automatiko Service for database record Archetype</description>
 
+  <properties>
+    <!-- An archetype jar already is the sources: the -sources.jar produced here is a
+      byte-for-byte duplicate of the archetype artifact, so publishing it only burns
+      Maven Central file-count quota. -->
+    <maven.source.skip>true</maven.source.skip>
+  </properties>
+
   <build>
     <!-- default directory (test-classes) confuses @QuarkusTest -->
     <!-- see https://github.com/quarkusio/quarkus/issues/9162   -->

--- a/archetypes/automatiko-event-stream-archetype/pom.xml
+++ b/archetypes/automatiko-event-stream-archetype/pom.xml
@@ -16,6 +16,13 @@
   <name>Automatiko Engine :: Maven Archetypes :: Event Steam</name>
   <description>Automatiko Service for Event Stream Archetype</description>
 
+  <properties>
+    <!-- An archetype jar already is the sources: the -sources.jar produced here is a
+      byte-for-byte duplicate of the archetype artifact, so publishing it only burns
+      Maven Central file-count quota. -->
+    <maven.source.skip>true</maven.source.skip>
+  </properties>
+
   <build>
     <!-- default directory (test-classes) confuses @QuarkusTest -->
     <!-- see https://github.com/quarkusio/quarkus/issues/9162   -->

--- a/archetypes/automatiko-function-archetype/pom.xml
+++ b/archetypes/automatiko-function-archetype/pom.xml
@@ -16,6 +16,13 @@
   <name>Automatiko Engine :: Maven Archetypes :: Function</name>
   <description>Automatiko Function Archetype</description>
 
+  <properties>
+    <!-- An archetype jar already is the sources: the -sources.jar produced here is a
+      byte-for-byte duplicate of the archetype artifact, so publishing it only burns
+      Maven Central file-count quota. -->
+    <maven.source.skip>true</maven.source.skip>
+  </properties>
+
   <build>
     <!-- default directory (test-classes) confuses @QuarkusTest -->
     <!-- see https://github.com/quarkusio/quarkus/issues/9162   -->

--- a/archetypes/automatiko-function-flow-archetype/pom.xml
+++ b/archetypes/automatiko-function-flow-archetype/pom.xml
@@ -16,6 +16,13 @@
   <name>Automatiko Engine :: Maven Archetypes :: Function Flow</name>
   <description>Automatiko Function Flow Archetype</description>
 
+  <properties>
+    <!-- An archetype jar already is the sources: the -sources.jar produced here is a
+      byte-for-byte duplicate of the archetype artifact, so publishing it only burns
+      Maven Central file-count quota. -->
+    <maven.source.skip>true</maven.source.skip>
+  </properties>
+
   <build>
     <!-- default directory (test-classes) confuses @QuarkusTest -->
     <!-- see https://github.com/quarkusio/quarkus/issues/9162   -->

--- a/archetypes/automatiko-iot-archetype/pom.xml
+++ b/archetypes/automatiko-iot-archetype/pom.xml
@@ -16,6 +16,13 @@
   <name>Automatiko Engine :: Maven Archetypes :: IoT</name>
   <description>Automatiko Service for IoT Archetype</description>
 
+  <properties>
+    <!-- An archetype jar already is the sources: the -sources.jar produced here is a
+      byte-for-byte duplicate of the archetype artifact, so publishing it only burns
+      Maven Central file-count quota. -->
+    <maven.source.skip>true</maven.source.skip>
+  </properties>
+
   <build>
     <!-- default directory (test-classes) confuses @QuarkusTest -->
     <!-- see https://github.com/quarkusio/quarkus/issues/9162   -->

--- a/archetypes/automatiko-operator-archetype/pom.xml
+++ b/archetypes/automatiko-operator-archetype/pom.xml
@@ -16,6 +16,13 @@
   <name>Automatiko Engine :: Maven Archetypes :: Kubernetes Operator</name>
   <description>Automatiko Service for Kubernetes Operator Archetype</description>
 
+  <properties>
+    <!-- An archetype jar already is the sources: the -sources.jar produced here is a
+      byte-for-byte duplicate of the archetype artifact, so publishing it only burns
+      Maven Central file-count quota. -->
+    <maven.source.skip>true</maven.source.skip>
+  </properties>
+
   <build>
     <!-- default directory (test-classes) confuses @QuarkusTest -->
     <!-- see https://github.com/quarkusio/quarkus/issues/9162   -->

--- a/archetypes/automatiko-orchestration-archetype/pom.xml
+++ b/archetypes/automatiko-orchestration-archetype/pom.xml
@@ -16,6 +16,13 @@
   <name>Automatiko Engine :: Maven Archetypes :: Orchestration</name>
   <description>Automatiko Service for service orchestration Archetype</description>
 
+  <properties>
+    <!-- An archetype jar already is the sources: the -sources.jar produced here is a
+      byte-for-byte duplicate of the archetype artifact, so publishing it only burns
+      Maven Central file-count quota. -->
+    <maven.source.skip>true</maven.source.skip>
+  </properties>
+
   <build>
     <!-- default directory (test-classes) confuses @QuarkusTest -->
     <!-- see https://github.com/quarkusio/quarkus/issues/9162   -->

--- a/pom.xml
+++ b/pom.xml
@@ -823,19 +823,6 @@
                 </archive>
               </configuration>
             </execution>
-            <execution>
-              <id>test-jar</id>
-              <goals>
-                <goal>test-jar</goal>
-              </goals>
-              <configuration>
-                <skipIfEmpty>true</skipIfEmpty>
-                <excludes>
-                  <exclude>**/logback-test.xml</exclude>
-                  <exclude>**/jndi.properties</exclude>
-                </excludes>
-              </configuration>
-            </execution>
           </executions>
           <configuration>
             <archive>
@@ -855,12 +842,6 @@
               <id>attach-sources</id>
               <goals>
                 <goal>jar-no-fork</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>attach-test-sources</id>
-              <goals>
-                <goal>test-jar-no-fork</goal>
               </goals>
             </execution>
           </executions>
@@ -946,8 +927,8 @@
 
     <plugins>
       <plugin>
-        <!-- Entry needed to create test-jars even for packaging types war,
-          bundle, ... -->
+        <!-- Entry needed to apply the shared manifest configuration to all
+          packaging types -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
       </plugin>
@@ -1053,6 +1034,17 @@
 	          <configuration>
 	             <publishingServerId>central-portal</publishingServerId>
 	             <autoPublish>true</autoPublish>
+	             <!-- Maven Central publishing limits are counted per published file, and
+	                  signatures/checksums count too. Requesting only the checksums Central
+	                  actually requires (MD5 + SHA1) instead of the default (which adds
+	                  SHA256 + SHA512) removes two files per artifact - a third of the
+	                  release. See https://central.sonatype.org/publish/maven-central-publishing-limits/ -->
+	             <checksums>required</checksums>
+	             <!-- Modules that are part of the build but of no use to consumers -->
+	             <excludeArtifacts>
+	                <excludeArtifact>automatiko-quarkus-integration-test</excludeArtifact>
+	                <excludeArtifact>archetypes</excludeArtifact>
+	             </excludeArtifacts>
 	          </configuration>
 	        </plugin>
         </plugins>


### PR DESCRIPTION
Maven Central starts enforcing per-organization publishing limits on 2026-10-01 (1,167 files and 78 MB per month, three-month averages). Release 0.55.0 published 1,950 files and 409 MB, so roughly 1.8x the file limit and 5x the size limit at the current release cadence.

Almost all of the size was one accident: each of the nine archetype modules published a 30-56 MB -tests.jar (385 MB in total, 94% of the release). The archetypes redirect testOutputDirectory to target/test-compile to work around quarkusio/quarkus#9162, the archetype integration test builds full Quarkus projects underneath it, and the inherited test-jar execution packaged all of it, third-party jars included.

- Drop the test-jar and attach-test-sources executions. No module depends on an Automatiko test-jar, and consumers have no use for them.
- Ask the central publishing plugin for only the checksums Central requires (MD5 + SHA1). The default also requests SHA256 + SHA512, which is two extra published files per artifact.
- Exclude automatiko-quarkus-integration-test (an integration test module) and the archetypes aggregator pom (no module declares it as parent) from the deployment bundle.
- Skip the archetype -sources.jar, which is a byte-for-byte duplicate of the archetype artifact itself.

Together these take a release from 325 artifacts / 1,950 files / 409 MB to 259 artifacts / 1,036 files / 22 MB, inside both thresholds.

See https://central.sonatype.org/publish/maven-central-publishing-limits/